### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -15,11 +15,11 @@ class IntegrationTest(AssetLaunchingTestCase):
 
     def setUp(self):
         bus_port = self.service_port(5672, 'rabbitmq')
-        self.bus = BusClient.from_connection_fields(host='localhost', port=bus_port)
+        self.bus = BusClient.from_connection_fields(host='127.0.0.1', port=bus_port)
 
         sysconfd_port = self.service_port(8668, 'sysconfd')
         self.sysconfd = SysconfdClient(
-            'localhost',
+            '127.0.0.1',
             sysconfd_port,
             prefix='',
             https=False,


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6