### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,5 +1,3 @@
-docker
-docker-compose
 kombu
 pytest
 


### PR DESCRIPTION
why: to have the latest docker-compose