### PR TITLE
WAZO-2366 Migrate /get/update_ha_config using FastAPI

### DIFF
--- a/integration_tests/suite/test_api.py
+++ b/integration_tests/suite/test_api.py
@@ -143,7 +143,6 @@ class TestSysconfd(IntegrationTest):
 
         assert self._file_exists('/etc/local/resolv.conf')
 
-    @pytest.mark.skip(reason=FASTAPI_REASON)
     def test_ha_config(self):
         self._given_file_absent('/etc/xivo/ha.conf')
         bus_events = self.bus.accumulator('sysconfd.sentinel')

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'wazo_sysconfd.plugins': [
             'asterisk = wazo_sysconfd.plugins.asterisk.plugin:Plugin',
             'dhcp_update = wazo_sysconfd.plugins.dhcp_update.plugin:Plugin',
+            'ha_config = wazo_sysconfd.plugins.ha_config.plugin:Plugin',
             'hosts = wazo_sysconfd.plugins.hosts.plugin:Plugin',
             'request_handlers = wazo_sysconfd.plugins.request_handlers.plugin:Plugin',
             'status = wazo_sysconfd.plugins.status.plugin:Plugin',

--- a/wazo_sysconfd/config.py
+++ b/wazo_sysconfd/config.py
@@ -62,6 +62,7 @@ _DEFAULT_CONFIG = {
         'hosts': True,
         'request_handlers': True,
         'status': True,
+        'ha_config': True,
     },
 }
 

--- a/wazo_sysconfd/main.py
+++ b/wazo_sysconfd/main.py
@@ -8,10 +8,8 @@ from xivo.xivo_logging import get_log_level_by_name, setup_logging
 from .controller import Controller
 from .config import load_config
 
-config = None
 
 def main():
-    global config
     config = load_config(sys.argv[1:])
     setup_logging(
         config['log_file'], log_level=get_log_level_by_name(config['log_level'])

--- a/wazo_sysconfd/main.py
+++ b/wazo_sysconfd/main.py
@@ -8,8 +8,10 @@ from xivo.xivo_logging import get_log_level_by_name, setup_logging
 from .controller import Controller
 from .config import load_config
 
+config = None
 
 def main():
+    global config
     config = load_config(sys.argv[1:])
     setup_logging(
         config['log_file'], log_level=get_log_level_by_name(config['log_level'])

--- a/wazo_sysconfd/modules/tests/test_ha.py
+++ b/wazo_sysconfd/modules/tests/test_ha.py
@@ -12,7 +12,7 @@ from io import StringIO
 
 import mock
 
-from wazo_sysconfd.modules.ha import (
+from wazo_sysconfd.plugins.ha_config.ha import (
     HAConfigManager,
     _PostgresConfigUpdater,
     _CronFileInstaller,
@@ -36,7 +36,6 @@ def _new_ha_config(node_type, remote_address):
 
 
 def mock_subprocess_check_call(f):
-
     @functools.wraps(f)
     def decorator(*kargs):
         old_subprocess_check_call = subprocess.check_call
@@ -54,9 +53,9 @@ class TestHA(unittest.TestCase):
     def setUp(self):
         self._tmp_dir = tempfile.mkdtemp()
         self._ha_conf_file = os.path.join(self._tmp_dir, 'test_ha.conf')
-        self._ha_config_mgr = HAConfigManager(mock.Mock(),
-                                              mock.Mock(),
-                                              ha_conf_file=self._ha_conf_file)
+        self._ha_config_mgr = HAConfigManager(
+            mock.Mock(), mock.Mock(), ha_conf_file=self._ha_conf_file
+        )
 
     def tearDown(self):
         shutil.rmtree(self._tmp_dir)
@@ -125,7 +124,9 @@ class TestHA(unittest.TestCase):
 
         self._ha_config_mgr._manage_services(ha_config)
 
-        subprocess.check_call.assert_called_with(['/usr/sbin/xivo-manage-slave-services', 'start'], close_fds=True)
+        subprocess.check_call.assert_called_with(
+            ['/usr/sbin/xivo-manage-slave-services', 'start'], close_fds=True
+        )
 
     @mock_subprocess_check_call
     def test_manage_services_master(self):
@@ -133,7 +134,9 @@ class TestHA(unittest.TestCase):
 
         self._ha_config_mgr._manage_services(ha_config)
 
-        subprocess.check_call.assert_called_with(['/usr/sbin/xivo-manage-slave-services', 'start'], close_fds=True)
+        subprocess.check_call.assert_called_with(
+            ['/usr/sbin/xivo-manage-slave-services', 'start'], close_fds=True
+        )
 
     @mock_subprocess_check_call
     def test_manage_services_slave(self):
@@ -147,8 +150,12 @@ class TestHA(unittest.TestCase):
 class TestPostgresConfigUpdater(unittest.TestCase):
     def setUp(self):
         self._tmp_dir = tempfile.mkdtemp()
-        self._pg_hba_filename = os.path.join(self._tmp_dir, _PostgresConfigUpdater.PG_HBA_FILE)
-        self._postgresql_filename = os.path.join(self._tmp_dir, _PostgresConfigUpdater.POSTGRESQL_FILE)
+        self._pg_hba_filename = os.path.join(
+            self._tmp_dir, _PostgresConfigUpdater.PG_HBA_FILE
+        )
+        self._postgresql_filename = os.path.join(
+            self._tmp_dir, _PostgresConfigUpdater.POSTGRESQL_FILE
+        )
 
     def tearDown(self):
         shutil.rmtree(self._tmp_dir)

--- a/wazo_sysconfd/plugins/ha_config/ha.py
+++ b/wazo_sysconfd/plugins/ha_config/ha.py
@@ -5,21 +5,20 @@ import errno
 import json
 import os
 import subprocess
-from xivo import http_json_server
-from xivo.http_json_server import CMD_R, CMD_RW
 
 
 class HAConfigManager(object):
     DEFAULT_HA_CONF_FILE = '/etc/xivo/ha.conf'
-    DEFAULT_HA_CONFIG = {
-        'node_type': 'disabled',
-        'remote_address': ''
-    }
+    DEFAULT_HA_CONFIG = {'node_type': 'disabled', 'remote_address': ''}
     CRONFILE_SLAVE = 'xivo-ha-slave'
     CRONFILE_MASTER = 'xivo-ha-master'
 
-    def __init__(self, postgres_config_updater_factory, cronfile_installer,
-                 ha_conf_file=DEFAULT_HA_CONF_FILE):
+    def __init__(
+        self,
+        postgres_config_updater_factory,
+        cronfile_installer,
+        ha_conf_file=DEFAULT_HA_CONF_FILE,
+    ):
         self._postgres_config_updater_factory = postgres_config_updater_factory
         self._cronfile_installer = cronfile_installer
         self._ha_conf_file = ha_conf_file
@@ -71,12 +70,17 @@ class HAConfigManager(object):
             self._add_slave_cronfile(remote_address)
 
     def _add_master_cronfile(self, remote_address):
-        content = '0 * * * * root /usr/sbin/xivo-master-slave-db-replication %s >/dev/null\n' \
-                  '0 * * * * root /usr/bin/xivo-sync >/dev/null\n' % remote_address
+        content = (
+            '0 * * * * root /usr/sbin/xivo-master-slave-db-replication %s >/dev/null\n'
+            '0 * * * * root /usr/bin/xivo-sync >/dev/null\n' % remote_address
+        )
         self._cronfile_installer.add_cronfile(self.CRONFILE_MASTER, content)
 
     def _add_slave_cronfile(self, remote_address):
-        content = '* * * * * root /usr/sbin/xivo-check-master-status %s >/dev/null\n' % remote_address
+        content = (
+            '* * * * * root /usr/sbin/xivo-check-master-status %s >/dev/null\n'
+            % remote_address
+        )
         self._cronfile_installer.add_cronfile(self.CRONFILE_SLAVE, content)
 
     def _manage_services(self, ha_config):
@@ -147,10 +151,3 @@ class _CronFileInstaller(object):
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
-
-
-ha_config_manager = HAConfigManager(_PostgresConfigUpdater, _CronFileInstaller())
-http_json_server.register(ha_config_manager.get_ha_config, CMD_R,
-                          name='get_ha_config')
-http_json_server.register(ha_config_manager.update_ha_config, CMD_RW,
-                          name='update_ha_config')

--- a/wazo_sysconfd/plugins/ha_config/http.py
+++ b/wazo_sysconfd/plugins/ha_config/http.py
@@ -4,7 +4,7 @@
 from fastapi import APIRouter, Depends, Body
 
 from wazo_sysconfd.plugins.ha_config.ha import HAConfigManager
-from wazo_sysconfd.settings import get_ha_config_manager
+from wazo_sysconfd.plugins.ha_config.plugin import get_ha_config_manager
 
 router = APIRouter()
 

--- a/wazo_sysconfd/plugins/ha_config/http.py
+++ b/wazo_sysconfd/plugins/ha_config/http.py
@@ -1,0 +1,22 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from fastapi import APIRouter, Depends, Body
+
+from wazo_sysconfd.plugins.ha_config.ha import HAConfigManager
+from wazo_sysconfd.settings import get_ha_config_manager
+
+router = APIRouter()
+
+
+@router.get('/get_ha_config', status_code=200)
+def get_ha_config(ha_config_manager: HAConfigManager = Depends(get_ha_config_manager)):
+    return ha_config_manager.get_ha_config(None, None)
+
+
+@router.post('/update_ha_config', status_code=200)
+def post_update_ha_config(
+    body: dict = Body(),
+    ha_config_manager: HAConfigManager = Depends(get_ha_config_manager),
+):
+    ha_config_manager.update_ha_config(body, None)

--- a/wazo_sysconfd/plugins/ha_config/plugin.py
+++ b/wazo_sysconfd/plugins/ha_config/plugin.py
@@ -1,0 +1,10 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from .http import router
+
+
+class Plugin:
+    def load(self, dependencies: dict):
+        api = dependencies['api']
+        api.include_router(router)

--- a/wazo_sysconfd/plugins/ha_config/plugin.py
+++ b/wazo_sysconfd/plugins/ha_config/plugin.py
@@ -1,10 +1,22 @@
 # Copyright 2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from .http import router
+from functools import lru_cache
+
+from wazo_sysconfd.plugins.ha_config.ha import (
+    HAConfigManager,
+    _PostgresConfigUpdater,
+    _CronFileInstaller,
+)
 
 
 class Plugin:
     def load(self, dependencies: dict):
+        from .http import router
         api = dependencies['api']
         api.include_router(router)
+
+
+@lru_cache()
+def get_ha_config_manager():
+    return HAConfigManager(_PostgresConfigUpdater, _CronFileInstaller())

--- a/wazo_sysconfd/settings.py
+++ b/wazo_sysconfd/settings.py
@@ -4,18 +4,8 @@
 from functools import lru_cache
 
 from wazo_sysconfd.plugins.asterisk.asterisk import Asterisk
-from wazo_sysconfd.plugins.ha_config.ha import (
-    HAConfigManager,
-    _PostgresConfigUpdater,
-    _CronFileInstaller,
-)
 
 
 @lru_cache()
 def get_asterisk():
     return Asterisk()
-
-
-@lru_cache()
-def get_ha_config_manager():
-    return HAConfigManager(_PostgresConfigUpdater, _CronFileInstaller())

--- a/wazo_sysconfd/settings.py
+++ b/wazo_sysconfd/settings.py
@@ -4,8 +4,18 @@
 from functools import lru_cache
 
 from wazo_sysconfd.plugins.asterisk.asterisk import Asterisk
+from wazo_sysconfd.plugins.ha_config.ha import (
+    HAConfigManager,
+    _PostgresConfigUpdater,
+    _CronFileInstaller,
+)
 
 
 @lru_cache()
 def get_asterisk():
     return Asterisk()
+
+
+@lru_cache()
+def get_ha_config_manager():
+    return HAConfigManager(_PostgresConfigUpdater, _CronFileInstaller())


### PR DESCRIPTION
As Python 2 is no more maintained, this endpoint is migrated to
Python 3 with FastApi