### PR TITLE
WAZO-2368 Migrate xivoctl using FastAPI

### DIFF
--- a/integration_tests/suite/test_api.py
+++ b/integration_tests/suite/test_api.py
@@ -176,7 +176,6 @@ class TestSysconfd(IntegrationTest):
 
         assert result == {'rest_api': {'status': 'ok'}}
 
-    @pytest.mark.skip(reason=FASTAPI_REASON)
     def test_xivoctl(self):
         bus_events = self.bus.accumulator('sysconfd.sentinel')
         body = {

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             'hosts = wazo_sysconfd.plugins.hosts.plugin:Plugin',
             'request_handlers = wazo_sysconfd.plugins.request_handlers.plugin:Plugin',
             'status = wazo_sysconfd.plugins.status.plugin:Plugin',
+            'xivoctl = wazo_sysconfd.plugins.xivoctl.plugin:Plugin',
         ],
     },
 )

--- a/wazo_sysconfd/config.py
+++ b/wazo_sysconfd/config.py
@@ -59,10 +59,11 @@ _DEFAULT_CONFIG = {
     'enabled_plugins': {
         'asterisk': True,
         'dhcp_update': True,
+        'ha_config': True,
         'hosts': True,
         'request_handlers': True,
         'status': True,
-        'ha_config': True,
+        'xivoctl': True,
     },
 }
 

--- a/wazo_sysconfd/modules/services.py
+++ b/wazo_sysconfd/modules/services.py
@@ -61,7 +61,8 @@ def _run_action_for_service_validated(service, action):
         p = subprocess.Popen(command,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT,
-                             close_fds=True)
+                             close_fds=True,
+                             encoding='UTF-8')
         output = p.communicate()[0]
         logger.debug("%s : return code %d", ' '.join(command), p.returncode)
 

--- a/wazo_sysconfd/modules/tests/test_services.py
+++ b/wazo_sysconfd/modules/tests/test_services.py
@@ -33,8 +33,8 @@ class TestServices(TestCase):
         services.services({service1: action1,
                            service2: action2}, sentinel.options)
 
-        mock_popen_constructor.assert_any_call(["/bin/systemctl", action1, "service1.service"], stdout=ANY, stderr=ANY, close_fds=ANY)
-        mock_popen_constructor.assert_any_call(["/bin/systemctl", action2, "service2.service"], stdout=ANY, stderr=ANY, close_fds=ANY)
+        mock_popen_constructor.assert_any_call(["/bin/systemctl", action1, "service1.service"], stdout=ANY, stderr=ANY, close_fds=ANY, encoding="UTF-8")
+        mock_popen_constructor.assert_any_call(["/bin/systemctl", action2, "service2.service"], stdout=ANY, stderr=ANY, close_fds=ANY, encoding="UTF-8")
 
     @patch('subprocess.Popen')
     def test_services_should_not_call_service_action_for_invalid_actions_service(self, mock_popen_constructor):
@@ -53,7 +53,7 @@ class TestServices(TestCase):
                            service5: action5},
                           sentinel.options)
 
-        mock_popen_constructor.assert_any_call(["/bin/systemctl", action1, "service1.service"], stdout=ANY, stderr=ANY, close_fds=ANY)
-        mock_popen_constructor.assert_any_call(["/bin/systemctl", action3, "service3.service"], stdout=ANY, stderr=ANY, close_fds=ANY)
-        mock_popen_constructor.assert_any_call(["/bin/systemctl", action5, "service5.service"], stdout=ANY, stderr=ANY, close_fds=ANY)
+        mock_popen_constructor.assert_any_call(["/bin/systemctl", action1, "service1.service"], stdout=ANY, stderr=ANY, close_fds=ANY, encoding="UTF-8")
+        mock_popen_constructor.assert_any_call(["/bin/systemctl", action3, "service3.service"], stdout=ANY, stderr=ANY, close_fds=ANY, encoding="UTF-8")
+        mock_popen_constructor.assert_any_call(["/bin/systemctl", action5, "service5.service"], stdout=ANY, stderr=ANY, close_fds=ANY, encoding="UTF-8")
         assert_that(mock_popen_constructor.call_count, equal_to(3))

--- a/wazo_sysconfd/plugins/xivoctl/http.py
+++ b/wazo_sysconfd/plugins/xivoctl/http.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from fastapi import APIRouter, Body
+
+from wazo_sysconfd.plugins.xivoctl.xivoctl import xivoctl
+
+router = APIRouter()
+
+
+@router.post('/xivoctl', status_code=200)
+def get_xivoctl(body: dict = Body()):
+    return xivoctl(body, None)

--- a/wazo_sysconfd/plugins/xivoctl/plugin.py
+++ b/wazo_sysconfd/plugins/xivoctl/plugin.py
@@ -1,0 +1,10 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from .http import router
+
+
+class Plugin:
+    def load(self, dependencies: dict):
+        api = dependencies['api']
+        api.include_router(router)

--- a/wazo_sysconfd/plugins/xivoctl/xivoctl.py
+++ b/wazo_sysconfd/plugins/xivoctl/xivoctl.py
@@ -4,9 +4,7 @@
 import logging
 import subprocess
 
-from xivo import http_json_server
-from xivo.http_json_server import HttpReqError
-from xivo.http_json_server import CMD_RW
+from wazo_sysconfd.exceptions import HttpReqError
 from wazo_sysconfd.modules.services import services
 
 logger = logging.getLogger('wazo_sysconfd.modules.xivoctl')
@@ -18,10 +16,12 @@ def xivoctl(args, options):
             try:
                 if act == 'start':
                     services({'asterisk': 'stop'}, {})
-                p = subprocess.Popen(["%s" % service, act],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT,
-                                     close_fds=True)
+                p = subprocess.Popen(
+                    ["%s" % service, act],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    close_fds=True,
+                )
                 output = p.communicate()[0]
                 logger.debug("%s %s : %d", service, act, p.returncode)
 
@@ -34,6 +34,3 @@ def xivoctl(args, options):
             logger.error("service not exist: %s", service)
 
     return output
-
-
-http_json_server.register(xivoctl, CMD_RW)


### PR DESCRIPTION
As Python 2 is no more maintained, this endpoint is migrated to Python 3
with FastAPI.