### PR TITLE
WAZO-2365 resolv_conf migrated to FastAPI

### DIFF
--- a/integration_tests/suite/test_api.py
+++ b/integration_tests/suite/test_api.py
@@ -129,7 +129,6 @@ class TestSysconfd(IntegrationTest):
         assert self._file_exists('/etc/hostname')
         assert self._file_exists('/etc/hosts')
 
-    @pytest.mark.skip(reason=FASTAPI_REASON)
     def test_resolv_conf(self):
         self._given_file_absent('/etc/local/resolv.conf')
         body = {

--- a/integration_tests/suite/test_api.py
+++ b/integration_tests/suite/test_api.py
@@ -1,8 +1,6 @@
 # Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import pytest
-
 from wazo_test_helpers import until
 
 from .helpers.base import IntegrationTest

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             'host_services = wazo_sysconfd.plugins.host_services.plugin:Plugin',
             'hosts = wazo_sysconfd.plugins.hosts.plugin:Plugin',
             'request_handlers = wazo_sysconfd.plugins.request_handlers.plugin:Plugin',
+            'resolv_conf = wazo_sysconfd.plugins.resolv_conf.plugin:Plugin',
             'status = wazo_sysconfd.plugins.status.plugin:Plugin',
             'xivoctl = wazo_sysconfd.plugins.xivoctl.plugin:Plugin',
         ],

--- a/wazo_sysconfd/config.py
+++ b/wazo_sysconfd/config.py
@@ -64,6 +64,7 @@ _DEFAULT_CONFIG = {
         'host_services': True,
         'hosts': True,
         'request_handlers': True,
+        'resolv_conf': True,
         'status': True,
         'xivoctl': True,
     },

--- a/wazo_sysconfd/dns_lock.py
+++ b/wazo_sysconfd/dns_lock.py
@@ -1,0 +1,6 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from xivo.moresynchro import RWLock
+
+RESOLVCONFLOCK = RWLock()

--- a/wazo_sysconfd/modules/resolvconf.py
+++ b/wazo_sysconfd/modules/resolvconf.py
@@ -8,15 +8,13 @@ import subprocess
 from time import time
 from shutil import copy2
 
-from xivo.moresynchro import RWLock
 from .utilities import txtsubst
 from xivo import system
 
 from wazo_sysconfd import exceptions, helpers
+from wazo_sysconfd.dns_lock import RESOLVCONFLOCK
 
 log = logging.getLogger('wazo_sysconfd.modules.resolvconf')
-
-RESOLVCONFLOCK = RWLock()
 
 Rcc = {
     'hostname_file': os.path.join(os.path.sep, 'etc', 'hostname'),

--- a/wazo_sysconfd/plugins/resolv_conf/http.py
+++ b/wazo_sysconfd/plugins/resolv_conf/http.py
@@ -1,0 +1,12 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from fastapi import APIRouter, Body
+
+from wazo_sysconfd.plugins.resolv_conf.resolv_conf import resolv_conf
+
+router = APIRouter()
+
+@router.post('/resolv_conf', status_code=200)
+def resolv_conf_post(body: dict = Body()):
+    return resolv_conf(body,None)

--- a/wazo_sysconfd/plugins/resolv_conf/http.py
+++ b/wazo_sysconfd/plugins/resolv_conf/http.py
@@ -8,5 +8,5 @@ from wazo_sysconfd.plugins.resolv_conf.resolv_conf import resolv_conf
 router = APIRouter()
 
 @router.post('/resolv_conf', status_code=200)
-def resolv_conf_post(body: dict = Body()):
+def post_resolv_conf(body: dict = Body()):
     return resolv_conf(body,None)

--- a/wazo_sysconfd/plugins/resolv_conf/plugin.py
+++ b/wazo_sysconfd/plugins/resolv_conf/plugin.py
@@ -1,0 +1,10 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from .http import router
+
+
+class Plugin:
+    def load(self, dependencies: dict):
+        api = dependencies['api']
+        api.include_router(router)

--- a/wazo_sysconfd/plugins/resolv_conf/plugin.py
+++ b/wazo_sysconfd/plugins/resolv_conf/plugin.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .http import router
+from .resolv_conf import safe_init
 
 
 class Plugin:
     def load(self, dependencies: dict):
+        safe_init(dependencies['config'])
         api = dependencies['api']
         api.include_router(router)

--- a/wazo_sysconfd/plugins/resolv_conf/resolv_conf.py
+++ b/wazo_sysconfd/plugins/resolv_conf/resolv_conf.py
@@ -9,14 +9,13 @@ from shutil import copy2
 
 from wazo_sysconfd.exceptions import HttpReqError
 from wazo_sysconfd.modules.utilities import txtsubst
-from xivo.moresynchro import RWLock
 from xivo import system
 
 from wazo_sysconfd import helpers
+from wazo_sysconfd.dns_lock import RESOLVCONFLOCK
 
 log = logging.getLogger('wazo_sysconfd.plugins.resolvconf')
 
-RESOLVCONFLOCK = RWLock()
 
 Rcc = {
     'hostname_file': os.path.join(os.path.sep, 'etc', 'hostname'),

--- a/wazo_sysconfd/plugins/resolv_conf/resolv_conf.py
+++ b/wazo_sysconfd/plugins/resolv_conf/resolv_conf.py
@@ -1,0 +1,159 @@
+# Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import logging
+
+from time import time
+from shutil import copy2
+
+from wazo_sysconfd.exceptions import HttpReqError
+from xivo.moresynchro import RWLock
+from xivo.xivo_config import txtsubst
+from xivo import system
+
+from wazo_sysconfd import helpers
+
+log = logging.getLogger('wazo_sysconfd.plugins.resolvconf')
+
+RESOLVCONFLOCK = RWLock()
+
+Rcc = {
+    'hostname_file': os.path.join(os.path.sep, 'etc', 'hostname'),
+    'hostname_tpl_file': os.path.join('resolvconf', 'hostname'),
+    'hosts_file': os.path.join(os.path.sep, 'etc', 'hosts'),
+    'hosts_tpl_file': os.path.join('resolvconf', 'hosts'),
+    'resolvconf_file': os.path.join(os.path.sep, 'etc', 'resolv.conf'),
+    'resolvconf_tpl_file': os.path.join('resolvconf', 'resolv.conf'),
+    'lock_timeout': 60,
+}
+
+
+def _write_config_file(optname, xvars):
+    backupfilename = None
+
+    if not os.path.isdir(Rcc["%s_backup_path" % optname]):
+        os.makedirs(Rcc["%s_backup_path" % optname])
+
+    if os.access(Rcc["%s_file" % optname], os.R_OK):
+        backupfilename = "%s.%d" % (Rcc["%s_backup_file" % optname], time())
+        copy2(Rcc["%s_file" % optname], backupfilename)
+
+    if os.access(Rcc["%s_custom_tpl_file" % optname], (os.F_OK | os.R_OK)):
+        filename = Rcc["%s_custom_tpl_file" % optname]
+    else:
+        filename = Rcc["%s_tpl_file" % optname]
+
+    template_file = open(filename)
+    template_lines = template_file.readlines()
+    template_file.close()
+
+    txt = txtsubst(
+        template_lines,
+        xvars,
+        Rcc["%s_file" % optname],
+        'utf8',
+    )
+
+    system.file_writelines_flush_sync(Rcc["%s_file" % optname], txt)
+
+    return backupfilename
+
+
+def _validate_hosts(args):
+    if not helpers.domain_label(args.get('hostname')):
+        raise HttpReqError(415, "invalid arguments for command")
+    if not helpers.search_domain(args.get('domain')):
+        raise HttpReqError(415, "invalid arguments for command")
+
+
+
+def _validate_resolv_conf(args):
+    nameservers = args.get('nameservers', [])
+    if not 0 < len(nameservers) < 4:
+        raise HttpReqError(415, "invalid arguments for command")
+    for nameserver in nameservers:
+        if not helpers.ipv4_address_or_domain(nameserver):
+            raise HttpReqError(415, "invalid arguments for command")
+
+    searches = args.get('search', [])
+    if not 0 < len(searches) < 7:
+        raise HttpReqError(415, "invalid arguments for command")
+    for search in searches:
+        if not helpers.search_domain(search):
+            raise HttpReqError(415, "invalid arguments for command")
+
+
+def _resolv_conf_variables(args):
+    xvars = {}
+    xvars['_XIVO_NAMESERVER_LIST'] = \
+        os.linesep.join(["nameserver %s"] * len(args['nameservers'])) % tuple(args['nameservers'])
+
+    if 'search' in args:
+        xvars['_XIVO_DNS_SEARCH'] = "search %s" % " ".join(args['search'])
+    else:
+        xvars['_XIVO_DNS_SEARCH'] = ""
+
+    return xvars
+
+
+def resolv_conf(args, options):
+    """
+    POST /resolv_conf
+
+    >>> resolv_conf({'nameservers': '192.168.0.254'})
+    >>> resolv_conf({'nameservers': ['192.168.0.254', '10.0.0.254']})
+    >>> resolv_conf({'search': ['toto.tld', 'tutu.tld']
+                     'nameservers': ['192.168.0.254', '10.0.0.254']})
+    """
+
+    if 'nameservers' in args:
+        args['nameservers'] = helpers.extract_scalar(args['nameservers'])
+        nameservers = helpers.unique_case_tuple(args['nameservers'])
+
+        if len(nameservers) == len(args['nameservers']):
+            args['nameservers'] = list(nameservers)
+        else:
+            raise HttpReqError(415, "duplicated nameservers in %r" % list(args['nameservers']))
+
+    if 'search' in args:
+        args['search'] = helpers.extract_scalar(args['search'])
+        search = helpers.unique_case_tuple(args['search'])
+
+        if len(search) == len(args['search']):
+            args['search'] = list(search)
+        else:
+            raise HttpReqError(415, "duplicated search in %r" % list(args['search']))
+
+        if len(''.join(args['search'])) > 255:
+            raise HttpReqError(
+                415,
+                "maximum length exceeded for option search: %r" % list(args['search']),
+            )
+
+    _validate_resolv_conf(args)
+
+    if not os.access(Rcc['resolvconf_path'], (os.X_OK | os.W_OK)):
+        raise HttpReqError(
+            415,
+            "path not found or not writable or not executable: %r" % Rcc['resolvconf_path'],
+        )
+
+    if not RESOLVCONFLOCK.acquire_read(Rcc['lock_timeout']):
+        raise HttpReqError(
+            503,
+            "unable to take RESOLVCONFLOCK for reading after %s seconds" % Rcc['lock_timeout'],
+        )
+
+    resolvconfbakfile = None
+
+    try:
+        try:
+            resolvconfbakfile = _write_config_file('resolvconf', _resolv_conf_variables(args))
+            return True
+        except Exception as e:
+            if resolvconfbakfile:
+                copy2(resolvconfbakfile, Rcc['resolvconf_file'])
+            raise e.__class__(str(e))
+    finally:
+        RESOLVCONFLOCK.release()

--- a/wazo_sysconfd/plugins/tests/test_resolvconf.py
+++ b/wazo_sysconfd/plugins/tests/test_resolvconf.py
@@ -1,0 +1,100 @@
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+
+from hamcrest import (
+    assert_that,
+    calling,
+    not_,
+    raises,
+)
+
+from wazo_sysconfd.exceptions import HttpReqError
+from wazo_sysconfd.plugins.resolv_conf.resolvconf import _validate_resolv_conf
+
+
+class TestValidateResolvConf(unittest.TestCase):
+
+    def test_nameservers(self):
+        assert_that(
+            calling(_validate_resolv_conf).with_args({}),
+            raises(HttpReqError),
+        )
+
+        assert_that(
+            calling(_validate_resolv_conf).with_args({'nameservers': []}),
+            raises(HttpReqError),
+        )
+
+        assert_that(
+            calling(_validate_resolv_conf).with_args(
+                {'nameservers': ['10.0.0.1', '10.0.0.2', '10.0.0.3', '10.0.0.4']},
+            ),
+            raises(HttpReqError),
+        )
+
+        invalid_ip_or_domain = [
+            '-foo.wazo-platform.org',
+            None,
+            'a' * 64,
+            '127.0.0.-1',
+        ]
+
+        for ip_or_domain in invalid_ip_or_domain:
+            assert_that(
+                calling(_validate_resolv_conf).with_args(
+                    {'nameservers': [ip_or_domain]},
+                ),
+                raises(HttpReqError),
+                ip_or_domain,
+            )
+
+    def test_search(self):
+        assert_that(
+            calling(_validate_resolv_conf).with_args({'nameservers': ['valid'], 'search': []}),
+            raises(HttpReqError),
+        )
+
+        assert_that(
+            calling(_validate_resolv_conf).with_args(
+                {
+                    'nameservers': ['valid'],
+                    'search': [
+                        'toto.1.tld',
+                        'toto.2.tld',
+                        'toto.3.tld',
+                        'toto.4.tld',
+                        'toto.5.tld',
+                        'toto.6.tld',
+                        'toto.7.tld',
+                    ],
+                },
+            ),
+            raises(HttpReqError),
+        )
+
+        invalid_names = [
+            64 * 'a' + '.wazo-platform.org',
+            '-NOT',
+            'NOT-',
+            'foo!bar',
+            'foo.-NOT.bar',
+        ]
+
+        for name in invalid_names:
+            body = {
+                'nameservers': ['valid'],
+                'search': [name],
+            }
+            assert_that(
+                calling(_validate_resolv_conf).with_args(body),
+                raises(HttpReqError),
+                name,
+            )
+
+        valid_body = {'nameservers': ['valid'], 'search': ['valid']}
+        assert_that(
+            calling(_validate_resolv_conf).with_args(valid_body),
+            not_(raises(Exception)),
+        )

--- a/wazo_sysconfd/plugins/tests/test_resolvconf.py
+++ b/wazo_sysconfd/plugins/tests/test_resolvconf.py
@@ -11,7 +11,7 @@ from hamcrest import (
 )
 
 from wazo_sysconfd.exceptions import HttpReqError
-from wazo_sysconfd.plugins.resolv_conf.resolvconf import _validate_resolv_conf
+from wazo_sysconfd.plugins.resolv_conf.resolv_conf import _validate_resolv_conf
 
 
 class TestValidateResolvConf(unittest.TestCase):


### PR DESCRIPTION
As Python 2 is no more maintained, resolv-conf module
has been updated to Python 3/FastAPI.