### PR TITLE
debian: add python3-typing-extensions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,9 @@ Depends: ${python3:Depends},
          python3-stevedore,
          python3-uvloop,
          rename,
-         sudo
+         sudo,
+# can be removed with python >3.8 (bullseye)
+         python3-typing-extensions
 Provides: xivo-sysconfd
 Conflicts: xivo-sysconfd
 Replaces: xivo-sysconfd


### PR DESCRIPTION
why: fastapi and its dependencies have been backported from bullseye,
which run with python3.9. To support new typing with older python
version (3.7), we need to install a compatibility package
"python3-typing-extensions"
This package can be removed when we will be on a newer python version
(i.e. when we will migrate to bullseye)