### PR TITLE
README: describe role of the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Build Status](https://jenkins.wazo.community/buildStatus/icon?job=wazo-sysconfd)](https://jenkins.wazo.community/job/wazo-sysconfd)
 
 wazo-sysconfd is a daemon for configuring system parameters on a Wazo server
+It is used to execute command requiring special privilege of a system (ex: root, asterisk). It shims
+Wazo and the installed host together. It usages is mandatory for a traditional installation of Wazo,
+but *should* be not necessary for container installations
 
 ## Running unit tests
 


### PR DESCRIPTION
why: avoid to consider wazo-sysconfd as a "tote bag"