### PR TITLE
pin importlib_metadata package

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,3 +1,4 @@
+importlib_metadata<5.0.0  # from kombu - https://github.com/celery/kombu/issues/1600
 kombu
 pyhamcrest
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 fastapi==0.63.0
 gunicorn==20.1.0
 httptools==0.0.11  # from uvicorn
+importlib_metadata==1.6.0  # from kombu
 kombu==4.2.1
 pydantic==1.7.4
 pyyaml==3.13


### PR DESCRIPTION
why: kombu use this library without pinning, and the latest version
(5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version