### PR TITLE
Added sentinel files to HA plugin

### DIFF
--- a/integration_tests/docker/Dockerfile-sysconfd-test
+++ b/integration_tests/docker/Dockerfile-sysconfd-test
@@ -9,6 +9,7 @@ RUN python setup.py develop \
     && adduser --quiet --system --group --no-create-home --home /var/lib/asterisk asterisk \
     && mkdir -p /etc/cron.d \
     && mkdir -p /etc/local \
+    && mkdir -p /var/lib/wazo \
     && ln -s /usr/local/bin/mock-command /bin/systemctl \
     && ln -s /usr/local/bin/mock-command /usr/bin/asterisk \
     && ln -s /usr/local/bin/mock-command /usr/local/bin/dhcpd-update \

--- a/wazo_sysconfd/plugins/ha_config/dependencies.py
+++ b/wazo_sysconfd/plugins/ha_config/dependencies.py
@@ -7,9 +7,12 @@ from wazo_sysconfd.plugins.ha_config.ha import (
     HAConfigManager,
     _PostgresConfigUpdater,
     _CronFileInstaller,
+    _SentinelFileManager,
 )
 
 
 @lru_cache()
 def get_ha_config_manager():
-    return HAConfigManager(_PostgresConfigUpdater, _CronFileInstaller())
+    return HAConfigManager(
+        _PostgresConfigUpdater, _CronFileInstaller(), _SentinelFileManager()
+    )

--- a/wazo_sysconfd/plugins/ha_config/ha.py
+++ b/wazo_sysconfd/plugins/ha_config/ha.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class NodeType(str, Enum):
-    SECONDARY = "slave"
-    PRIMARY = "master"
-    DISABLED = "disabled"
+    SECONDARY = 'slave'
+    PRIMARY = 'master'
+    DISABLED = 'disabled'
 
 
 class HAConfigManager(object):
@@ -173,8 +173,8 @@ class _CronFileInstaller(object):
 
 class _SentinelFileManager:
     SENTINEL_ROOT_DIR = Path('/var/lib/wazo')
-    PRIMARY_SENTINEL_NAME = "is-primary"
-    SECONDARY_SENTINEL_NAME = "is-secondary"
+    PRIMARY_SENTINEL_NAME = 'is-primary'
+    SECONDARY_SENTINEL_NAME = 'is-secondary'
 
     def __init__(self, root_dir: os.PathLike = SENTINEL_ROOT_DIR):
         self._root_dir = Path(root_dir)
@@ -185,30 +185,30 @@ class _SentinelFileManager:
         if self._secondary_sentinel.exists():
             self._secondary_sentinel.unlink()
         sentinel = self._primary_sentinel
-        logger.info("Creating primary sentinel file %s.", sentinel)
+        logger.info('Creating primary sentinel file %s.', sentinel)
         sentinel.touch()
 
     def _install_secondary(self):
         if self._primary_sentinel.exists():
             self._primary_sentinel.unlink()
         sentinel = self._secondary_sentinel
-        logger.info("Creating secondary sentinel file %s.", sentinel)
+        logger.info('Creating secondary sentinel file %s.', sentinel)
         sentinel.touch()
 
     def install(self, ha_config: dict):
-        mode = NodeType(ha_config["node_type"])
+        mode = NodeType(ha_config['node_type'])
         if mode is NodeType.SECONDARY:
-            logger.info("Node is in secondary HA mode.")
+            logger.info('Node is in secondary HA mode.')
             self._install_secondary()
         elif mode is NodeType.PRIMARY:
-            logger.info("Node is in primary HA mode.")
+            logger.info('Node is in primary HA mode.')
             self._install_primary()
         elif mode is NodeType.DISABLED:
-            logger.info("HA disabled on this node.")
+            logger.info('HA disabled on this node.')
             self.uninstall(ha_config)
 
     def uninstall(self, ha_config: dict):
-        logger.info("Removing sentinel files.")
+        logger.info('Removing sentinel files.')
         if self._primary_sentinel.exists():
             self._primary_sentinel.unlink()
         if self._secondary_sentinel.exists():

--- a/wazo_sysconfd/plugins/ha_config/tests/test_ha.py
+++ b/wazo_sysconfd/plugins/ha_config/tests/test_ha.py
@@ -351,25 +351,25 @@ class TestSentinelFilesManager(unittest.TestCase):
         shutil.rmtree(self.root_dir)
 
     def test_primary(self):
-        ha_config = new_master_ha_config("10.0.0.1")
+        ha_config = new_master_ha_config('10.0.0.1')
         self.sentinel_file_manager.install(ha_config)
-        sentinel_file = self.root_dir / "is-primary"
+        sentinel_file = self.root_dir / 'is-primary'
         self.assertTrue(sentinel_file.exists())
-        anti_sentinel_file = self.root_dir / "is-secondary"
+        anti_sentinel_file = self.root_dir / 'is-secondary'
         self.assertFalse(anti_sentinel_file.exists())
 
     def test_secondary(self):
-        ha_config = new_slave_ha_config("10.0.0.2")
+        ha_config = new_slave_ha_config('10.0.0.2')
         self.sentinel_file_manager.install(ha_config)
-        sentinel_file = self.root_dir / "is-secondary"
+        sentinel_file = self.root_dir / 'is-secondary'
         self.assertTrue(sentinel_file.exists())
-        anti_sentinel_file = self.root_dir / "is-primary"
+        anti_sentinel_file = self.root_dir / 'is-primary'
         self.assertFalse(anti_sentinel_file.exists())
 
     def test_disabled(self):
         ha_config = new_disabled_ha_config()
         self.sentinel_file_manager.install(ha_config)
-        primary_sentinel_file = self.root_dir / "is-primary"
-        secondary_sentinel_file = self.root_dir / "is-secondary"
+        primary_sentinel_file = self.root_dir / 'is-primary'
+        secondary_sentinel_file = self.root_dir / 'is-secondary'
         self.assertFalse(primary_sentinel_file.exists())
         self.assertFalse(secondary_sentinel_file.exists())


### PR DESCRIPTION
* HAConfigManager updated to manage sentinel files to reflect HA mode status of the node
* integration tests docker environment updated with a /var/lib/wazo directory

## Test coverage
* wazo_sysconfd/plugins/ha_config/tests/test_ha.py: TestSentinelFilesManager

## Related PRs
* https://github.com/wazo-platform/wazo-upgrade/pull/75
* https://github.com/wazo-platform/xivo-config/pull/79