### PR TITLE
populate server uuid config for event origin_uuid

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -8,6 +8,8 @@ services:
 
   sysconfd:
     image: wazoplatform/wazo-sysconfd-tests
+    environment:
+      XIVO_UUID: 00000000-0000-0000-0000-0000575c04fd
     ports:
       - "8668"
     volumes:

--- a/wazo_sysconfd/main.py
+++ b/wazo_sysconfd/main.py
@@ -1,12 +1,16 @@
 # Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import sys
 
 from xivo.xivo_logging import setup_logging
+from xivo.config_helper import set_xivo_uuid
 
 from .controller import Controller
 from .config import load_config
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -16,5 +20,6 @@ def main():
         debug=config['debug'],
         log_level=config['log_level'],
     )
+    set_xivo_uuid(config, logger)
     controller = Controller(config)
     controller.run()


### PR DESCRIPTION
why: otherwise event will be sent with origin_uuid:null and nobody will
be able to bind to these events

On recent websocketd refactor, the minimum binding requirement
is origin_uuid to avoid mixin events when you federate many rabbitmq