### PR TITLE
use gunicorn hooks to close bus_manager

### DIFF
--- a/wazo_sysconfd/controller.py
+++ b/wazo_sysconfd/controller.py
@@ -17,8 +17,12 @@ logger = logging.getLogger(__name__)
 class Controller:
     def __init__(self, config: dict):
         self.config = config
+
         self.bus_manager = BusManager(config)
-        self.http_server = SysconfdApplication('%(prog)s', config=config)
+
+        self.http_server = SysconfdApplication(
+            '%(prog)s', config=config, bus_manager=self.bus_manager
+        )
         self.status_aggregator = StatusAggregator()
 
         self.bus_manager.start()
@@ -42,7 +46,4 @@ class Controller:
 
     def run(self):
         logger.info('wazo-sysconfd starting...')
-        try:
-            self.http_server.run()
-        finally:
-            self.bus_manager.stop()
+        self.http_server.run()

--- a/wazo_sysconfd/http_server.py
+++ b/wazo_sysconfd/http_server.py
@@ -6,14 +6,16 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from gunicorn.app.base import BaseApplication
 
+from wazo_sysconfd.bus import BusManager
 from wazo_sysconfd.exceptions import HttpReqError
 
 api = FastAPI(title='wazo-sysconfd', openapi_url='/api/api.yml')
 
 
 class SysconfdApplication(BaseApplication):
-    def __init__(self, *args, config: dict = None, **kwargs):
+    def __init__(self, *args, config: dict = None, bus_manager: BusManager, **kwargs):
         self.config = config or {}
+        self.bus_manager = bus_manager
         super().__init__(*args, **kwargs)
 
     def load_config(self):
@@ -24,6 +26,8 @@ class SysconfdApplication(BaseApplication):
         self.cfg.set('loglevel', logging.getLevelName(self.config['log_level']))
         self.cfg.set('accesslog', '-')
         self.cfg.set('errorlog', '-')
+        self.cfg.set('post_worker_init', self.post_worker_init)
+        self.cfg.set('on_exit', self.on_exit)
         # NOTE: We must set this to one worker, since each worker is its own process, and if we have more than one
         # they will each get their own queue and then not respect the execution order which creates concurrency issues.
         self.cfg.set('workers', 1)
@@ -32,6 +36,17 @@ class SysconfdApplication(BaseApplication):
 
     def load(self):
         return api
+
+    # Because gunicorn is using the forking model, We must deactivate the multiprocessing atexit default handler.
+    # If not, it will trigger an exception when shutting down (thinking it owns the bus_manager process)
+    def post_worker_init(self, worker):
+        import atexit
+        from multiprocessing.util import _exit_function
+
+        atexit.unregister(_exit_function)
+
+    def on_exit(self, server):
+        self.bus_manager.stop()
 
 
 @api.exception_handler(HttpReqError)


### PR DESCRIPTION
Why:

* By using the hook, we are only closing the bus manager when gunicorn is shutdown.

* Using the hook avoids traceback when shutting down workers. Because of the forking model gunicorn uses, each worker thinks they inherit the bus manager as a child process, which they will try to close when shutting down.  This results in a traceback because workers cannot shutdown the bus manager,  only the master process can.