### PR TITLE
remove project definition from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "wazo_sysconfd"
-version = '2.0'
-
 [tool.black]
 skip-string-normalization = true
 


### PR DESCRIPTION
why: this config break usage of "pip install -e ." by not creating the
binary. Since no other repo have this section, the solution to remove
the section seems "more standard"