### PR TITLE
remove uvloop dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,6 @@ Depends: ${python3:Depends},
          python3-kombu,
          python3-netifaces,
          python3-stevedore,
-         python3-uvloop,
          rename,
          sudo
 Provides: xivo-sysconfd

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ requests==2.25.1
 starlette==0.14.2  # Bullseye actually includes version of 0.14.1
 stevedore==3.2.2
 uvicorn==0.13.3
-uvloop==0.17.0  # from uvicorn (Bullseye has 0.14.0, but it won't build from pip)


### PR DESCRIPTION
why: after tests with websocketd, uvloop is not much better than the
standard implementation. Moreover, the uvloop from bullseye is not fully
compatible with python3.9 ... It doesn't cause any issue for sysconfd,
but have an issue for websocketd. This service is also not intensively
used. For these reasons and reduce dependencies, uvloop could be
removed.