### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # - "${LOCAL_GIT_REPOS}/wazo-bus/wazo_bus:/opt/venv/lib/python3.11/site-packages/wazo_bus"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ kombu==5.2.4
 pydantic==1.10.4
 pyyaml==6.0
 requests==2.28.1
+setuptools==66.1.1
 starlette==0.26.1
 stevedore==4.0.2
 uvicorn==0.17.6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: pins an integration-test RabbitMQ container to a stable major version and adds an explicit Python build dependency; no application logic changes.
> 
> **Overview**
> Pins the integration-test `rabbitmq` service image from `rabbitmq` (latest) to `rabbitmq:3` to avoid unexpected breaking changes from upstream tag updates.
> 
> Adds an explicit `setuptools==66.1.1` entry to `requirements.txt` to ensure the dependency is available during installs/builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b08492e7ffb60bfb20a4c98c11d78c26696879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->