### PR TITLE
add `--no-cache` to integration tests to pickup dependencies changes

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,7 +1,7 @@
 test-setup: test-image egg-info
 
 test-image:
-	docker build -t wazoplatform/wazo-sysconfd ..
+	docker build --no-cache -t wazoplatform/wazo-sysconfd ..
 	docker build --no-cache -t wazoplatform/wazo-sysconfd-tests -f docker/Dockerfile-sysconfd-test ..
 
 egg-info:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Makefile change affecting only integration test image builds; primary impact is slower builds and potential exposure of previously cached dependency issues.
> 
> **Overview**
> Integration tests now build the `wazo-sysconfd` Docker image with `--no-cache`, matching the existing behavior for the test image so dependency updates aren’t hidden by Docker layer caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04918780035941d0d170f8a4452580f2b40e5327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->